### PR TITLE
Added prefix on got request

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ const getJwtData = (header) => {
 }
 
 const verifyJwt = async (header) => {
-    const result = await got(`${process.env.AUTH_API_URL}/verify`, {headers: {authorization: header}})
+    const result = await got('verify', {prefixUrl: process.env.AUTH_API_URL, headers: {authorization: header}})
     return result
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+const got = require('got')
 const jwt = require('jsonwebtoken')
 
 const stripPrefix = (str, prefix) => {
@@ -10,7 +11,8 @@ const getJwtData = (header) => {
 }
 
 const verifyJwt = async (header) => {
-    return (await got(`${process.env.AUTH_API_URL}/verify`, {headers: {authorization: header}}))
+    const result = await got(`${process.env.AUTH_API_URL}/verify`, {headers: {authorization: header}})
+    return result
 }
 
 const protectedRouteValidator = {


### PR DESCRIPTION
The _got_ request used to verify the user's permissions previously relied on plain string concatenation to get the endpoint. This has been changed to use _got_'s _prefixUrl_ property.